### PR TITLE
business_type=11 in the message push

### DIFF
--- a/src/Resources/Chat.php
+++ b/src/Resources/Chat.php
@@ -71,11 +71,15 @@ class Chat extends Resource
     /**
      * API: v2.sellerchat.get_one_conversation
      * To get a specific conversation's basic information.
+     *
+     * business_type: If this parameter is not passed, the default value is 0, 11 is for seller affiliate chat
+     *
      */
-    public function getOneConversation($conversation_id)
+    public function getOneConversation($conversation_id, $business_type = 0)
     {
         $params = [
             'conversation_id' => $conversation_id,
+            'business_type' => $business_type,
         ];
 
         return $this->call('GET', 'sellerchat/get_one_conversation', [


### PR DESCRIPTION
In the scenario where business_type=11 in the message push, getOneConversation is requested to return "Error or loss in request parameter" to update the problem